### PR TITLE
Set -std=c99 -D_POSIX_C_SOURCE=200809L in default CFLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ include(cmake/install_utils.cmake)
 include(CMakeDependentOption)
 
 # compilation flags
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_DEFAULT_SOURCE")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_SVID_SOURCE -D_POSIX_C_SOURCE=200809L -std=c99")
 
 option(WITH_EXTRA_WARNINGS "Enable extra compilation warnings" OFF)
 if(WITH_EXTRA_WARNINGS)


### PR DESCRIPTION
Without this, compilation using the steps documented in README.md (cmake followed by make) fails for me on CentOS 7.