### PR TITLE
Fix keytool availability detection

### DIFF
--- a/tools/generate-certs.sh
+++ b/tools/generate-certs.sh
@@ -58,7 +58,7 @@ openssl pkcs8 -topk8 -in client.key -inform pem -outform der \
     -passin "pass:$KEYSTORE_PASSWORD" -nocrypt > client.key.der
 openssl x509 -in client.crt -outform der > client.crt.der
 
-if ! KEYTOOL="$(which keytool)" || [ -z "$KEYTOOL" ] || ! "$KEYTOOL" -version >/dev/null 2>/dev/null; then
+if ! KEYTOOL="$(which keytool)" || [ -z "$KEYTOOL" ] || ! "$KEYTOOL" -help >/dev/null 2>/dev/null; then
     echo ''
     echo "NOTE: keytool not found, not generating keystores for Java/Californium"
     echo ''


### PR DESCRIPTION
No keytool version seems to recognize the -version option. All do seem
to have -help, although pre-JDK 1.7 ones return an error code with it,
but they're unsupported these days anyway so this should be good
enough.