### PR TITLE
Fix type formating for lifetime

### DIFF
--- a/src/core/anjay_utils_core.c
+++ b/src/core/anjay_utils_core.c
@@ -290,7 +290,7 @@ avs_error_t _anjay_coap_add_query_options(avs_coap_options_t *opts,
     if (lifetime
             && avs_is_err((err = avs_coap_options_add_string_f(
                                    opts, AVS_COAP_OPTION_URI_QUERY,
-                                   "lt=%" PRId64, *lifetime)))) {
+                                   "lt=%" PRIi32, *lifetime)))) {
         return err;
     }
 


### PR DESCRIPTION
I'm using Anjay on a MCU and I'm facing an issue with the conversion of lifetime using vnsprintf because **%lld** is not supported.

Since the specification gives lifetime as a 32bit integer we can use **%li** instead to make it work.

You can find the definition of lifetime p76:
[LWM2M Spécification](http://openmobilealliance.org/RELEASE/LightweightM2M/V1_1-20180612-C/OMA-TS-LightweightM2M_Core-V1_1-20180612-C.pdf)

You can find the C data type here : 
[C Data types](https://en.wikipedia.org/wiki/C_data_types)