### PR TITLE
Fix hard to find bug with apt-get install change not refreshing apt index

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,7 @@ FROM ubuntu:20.04
 
 WORKDIR /Anjay
 
-RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -yq git build-essential cmake libmbedtls-dev zlib1g-dev
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq git build-essential cmake libmbedtls-dev zlib1g-dev
 
 COPY . .
 


### PR DESCRIPTION
In case of apt-get install list change, the apt-get update won't be run, which means that potentially outdated list of apt-get packages will be used in the build. This PR solves that by executing the layers as one command.