### PR TITLE
fluf: fix UB in get_option_from_buff

### DIFF
--- a/src/fluf/fluf_options.c
+++ b/src/fluf/fluf_options.c
@@ -81,13 +81,13 @@ static int get_option_from_buff(const uint8_t **buff_pointer,
         return res;
     }
     opt->option_number += last_opt_number;
-    size_t temp_payload_len = opt->payload_len;
-    res = update_extended_option((uint16_t *) &temp_payload_len, buff_pointer,
+    uint16_t temp_payload_len = (uint16_t)opt->payload_len;
+    res = update_extended_option(&temp_payload_len, buff_pointer,
                                  buff_end);
     if (res) {
         return res;
     }
-    opt->payload_len = temp_payload_len;
+    opt->payload_len = (size_t)temp_payload_len;
 
     // move to payload position
     (*buff_pointer)++;


### PR DESCRIPTION
Make temp_payload_len local of type uint16_t instead of size_t to pass a ptr to update_extended_option without causing undefined behaviour.

Function update_extended_option dereferences passed uint16_t ptr which in this case is pointing to size_t type.

When built with Arm GNU Toolchain 13.2.rel1 with flags:
```
-mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mthumb -Os -Wall
```
compiled code is incorrect which leads to `opt->payload_len` not being properly updated which subsequently leads to wrong if condition result which causes FLUF_ERR_BUFF error later on.

Signed-off-by: Piotr Zalewski piotr.zalewski@plum.pl